### PR TITLE
chore(build): migrate from Poetry to Hatchling build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,7 @@ Homepage = "https://github.com/jamesbconner/table-sleuth"
 Repository = "https://github.com/jamesbconner/table-sleuth"
 
 # Hatchling configuration for src layout
-[tool.hatch.build.targets.wheel]
-packages = ["table_sleuth"]
+# Removed to let hatchling auto determine the package in src
 
 # -----------------------
 # Ruff configuration


### PR DESCRIPTION
- Replace Poetry configuration with PEP 517/518 compliant build-system
- Convert tool.poetry metadata to standard [project] table format
- Reorganize dependencies into main and optional dev groups
- Update build backend from poetry-core to hatchling
- Configure Hatchling for src layout package discovery
- Standardize project metadata with classifiers and URLs
- Maintain all existing dependency versions and constraints
- Improves compatibility with modern Python packaging standards

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches from Poetry to Hatchling with PEP 621 metadata, reorganizes dependencies (including dev extras), and adds Bandit configuration.
> 
> - **Build/Packaging**:
>   - Replace `tool.poetry` with PEP 621 `project` metadata; set `build-system` to `hatchling`.
>   - Move runtime deps to `project.dependencies`; add `project.optional-dependencies.dev` (tests, linting, type-checking, pre-commit, Bandit).
>   - Define `project.scripts` entry point `table-sleuth`.
>   - Add metadata: classifiers, authors, license, URLs; set `requires-python`.
> - **Tooling**:
>   - Retain Ruff, mypy, and pytest configurations.
>   - Add `tool.bandit` configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dc28f1e7885c903429f65fdbc2257a165392408. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->