### PR TITLE
ruff updates

### DIFF
--- a/src/table_sleuth/__init__.py
+++ b/src/table_sleuth/__init__.py
@@ -1,3 +1,4 @@
 """Table Sleuth - open table format forensics."""
+
 __all__ = ["__version__"]
 __version__ = "0.1.0"

--- a/src/table_sleuth/models/__init__.py
+++ b/src/table_sleuth/models/__init__.py
@@ -1,8 +1,8 @@
-from .table import TableHandle
-from .snapshot import SnapshotInfo
 from .file_ref import FileRef
-from .parquet import ParquetFileInfo, ColumnStats
+from .parquet import ColumnStats, ParquetFileInfo
 from .profiling import ColumnProfile
+from .snapshot import SnapshotInfo
+from .table import TableHandle
 
 __all__ = [
     "TableHandle",

--- a/src/table_sleuth/models/file_ref.py
+++ b/src/table_sleuth/models/file_ref.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Any, Dict
 
@@ -7,9 +8,9 @@ from typing import Any, Dict
 class FileRef:
     path: str
     content_type: str
-    partition: Dict[str, Any]
+    partition: dict[str, Any]
     file_size_bytes: int
     record_count: int
     sequence_number: int
     data_sequence_number: int
-    extra: Dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)

--- a/src/table_sleuth/models/parquet.py
+++ b/src/table_sleuth/models/parquet.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -11,7 +12,7 @@ class ColumnStats:
     null_count: int
     min_value: Any | None
     max_value: Any | None
-    encodings: List[str]
+    encodings: list[str]
     compression: str
 
 
@@ -20,5 +21,5 @@ class ParquetFileInfo:
     path: str
     num_rows: int
     num_row_groups: int
-    row_group_sizes: List[int]
-    columns: List[ColumnStats]
+    row_group_sizes: list[int]
+    columns: list[ColumnStats]

--- a/src/table_sleuth/models/profiling.py
+++ b/src/table_sleuth/models/profiling.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+
 from typing import Any, Optional
+
 from pydantic import BaseModel
 
 

--- a/src/table_sleuth/models/snapshot.py
+++ b/src/table_sleuth/models/snapshot.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -11,6 +12,6 @@ class SnapshotInfo:
     parent_id: Optional[int]
     timestamp_ms: int
     operation: str
-    summary: Dict[str, str]
-    data_files: List[FileRef] = field(default_factory=list)
-    delete_files: List[FileRef] = field(default_factory=list)
+    summary: dict[str, str]
+    data_files: list[FileRef] = field(default_factory=list)
+    delete_files: list[FileRef] = field(default_factory=list)

--- a/src/table_sleuth/models/table.py
+++ b/src/table_sleuth/models/table.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any
 

--- a/src/table_sleuth/services/formats/iceberg.py
+++ b/src/table_sleuth/services/formats/iceberg.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Iterable, Optional
+from collections.abc import Iterable
+from typing import Optional
 
 from pyiceberg.catalog import load_catalog
-from pyiceberg.table import StaticTable, Table, Snapshot
+from pyiceberg.table import Snapshot, StaticTable, Table
 
-from table_sleuth.models import TableHandle, SnapshotInfo, FileRef
+from table_sleuth.models import FileRef, SnapshotInfo, TableHandle
+
 from .base import TableFormatAdapter
 
 

--- a/src/table_sleuth/services/mor_service.py
+++ b/src/table_sleuth/services/mor_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List
 
-from table_sleuth.models import SnapshotInfo, FileRef
+from table_sleuth.models import FileRef, SnapshotInfo
 
 
 @dataclass
@@ -24,11 +24,11 @@ class SnapshotMorSummary:
     total_effective_rows_estimate: int
     num_base_files: int
     num_delete_files: int
-    file_impacts: List[FileMorImpact]
+    file_impacts: list[FileMorImpact]
 
 
 def estimate_mor(snapshot: SnapshotInfo) -> SnapshotMorSummary:
-    delete_by_partition: Dict[str, List[FileRef]] = {}
+    delete_by_partition: dict[str, list[FileRef]] = {}
 
     for df in snapshot.delete_files:
         key = _partition_key(df.partition)

--- a/src/table_sleuth/services/parquet_service.py
+++ b/src/table_sleuth/services/parquet_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pyarrow.parquet import ParquetFile
 
-from table_sleuth.models import ParquetFileInfo, ColumnStats
+from table_sleuth.models import ColumnStats, ParquetFileInfo
 
 
 def inspect_parquet_file(path: str) -> ParquetFileInfo:
@@ -35,9 +35,7 @@ def inspect_parquet_file(path: str) -> ParquetFileInfo:
         ]
 
         compression = row_group_cols[0].compression
-        encodings = list(
-            {enc.name for c in row_group_cols for enc in (c.encodings or [])}
-        )
+        encodings = list({enc.name for c in row_group_cols for enc in (c.encodings or [])})
 
         columns.append(
             ColumnStats(
@@ -48,9 +46,7 @@ def inspect_parquet_file(path: str) -> ParquetFileInfo:
                 min_value=min(mins) if mins else None,
                 max_value=max(maxs) if maxs else None,
                 encodings=encodings,
-                compression=compression.name if hasattr(compression, "name") else str(
-                    compression
-                ),
+                compression=compression.name if hasattr(compression, "name") else str(compression),
             )
         )
 

--- a/src/table_sleuth/services/profiling/__init__.py
+++ b/src/table_sleuth/services/profiling/__init__.py
@@ -1,5 +1,5 @@
 from .backend_base import ProfilingBackend
-from .gizmo_duckdb import GizmoDuckDbProfiler
 from .fake_backend import FakeProfiler
+from .gizmo_duckdb import GizmoDuckDbProfiler
 
 __all__ = ["ProfilingBackend", "GizmoDuckDbProfiler", "FakeProfiler"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes typing to built-in generics and updates imports/formatting across models and services.
> 
> - **Typing/annotations**:
>   - Replace `typing.List`/`Dict` with built-in `list`/`dict` across `models` and services (`file_ref.py`, `parquet.py`, `snapshot.py`, `mor_service.py`, `parquet_service.py`).
>   - Use `collections.abc.Iterable` in `services/formats/iceberg.py`.
> - **Imports/exports**:
>   - Reorder imports and `__all__` declarations in `models/__init__.py` and `services/profiling/__init__.py`.
> - **Formatting/cleanup**:
>   - Minor code compacting in `parquet_service.py` and whitespace tweaks in package `__init__.py`.
> - **No new functionality added; structure and signatures remain the same.**
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9126e09a94cb265232f257e80f3475fe69823ebd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->