### PR TITLE
feat(tui): add Docker path conversion for GizmoSQL profiling

### DIFF
--- a/src/table_sleuth/tui/app.py
+++ b/src/table_sleuth/tui/app.py
@@ -456,6 +456,22 @@ class TableSleuthApp(App):
             # App not mounted yet
             logger.warning("Cannot profile: app not mounted")
 
+    def _convert_to_docker_path(self, local_path: str) -> str:
+        """Convert local file path to Docker container path.
+
+        GizmoSQL runs in Docker with /data mounted to ./data, so we need to
+        convert local paths to Docker paths for profiling to work.
+
+        Args:
+            local_path: Local file path (e.g., "data/warehouse/...")
+
+        Returns:
+            Docker path (e.g., "/data/warehouse/...")
+        """
+        if local_path.startswith("data/"):
+            return "/data/" + local_path[5:]  # Remove "data/" and add "/data/"
+        return local_path
+
     def _profile_column(self, column_name: str) -> None:
         """Profile a column using the profiling backend.
 
@@ -480,9 +496,10 @@ class TableSleuthApp(App):
             else:
                 # Register file view if not already registered
                 if self._current_view_name is None:
-                    self._current_view_name = self._profiler.register_file_view(
-                        [self._current_file_info.path]
-                    )
+                    # Convert local path to Docker path for GizmoSQL
+                    docker_path = self._convert_to_docker_path(self._current_file_info.path)
+                    logger.debug(f"Registering file view: {docker_path}")
+                    self._current_view_name = self._profiler.register_file_view([docker_path])
 
                 # Profile the column
                 profile_result = self._profiler.profile_single_column(

--- a/table_sleuth.toml
+++ b/table_sleuth.toml
@@ -8,12 +8,12 @@ default = "local"
 # GizmoSQL connection settings for column profiling
 # Update these with your actual GizmoSQL credentials
 uri = "grpc+tls://localhost:31337"
-username = "gizmo"
-password = "gizmo"
+username = "gizmosql_username"
+password = "gizmosql_password"
 tls_skip_verify = true
 
 # Note: If you don't have GizmoSQL running, profiling features won't work
 # but all other features (file inspection, schema viewing, etc.) will still work.
 #
 # To start GizmoSQL:
-# docker run -d --name gizmosql -p 31337:31337 --volume "$(pwd)/data:/data" gizmosql/gizmosql:latest
+# docker run --name gizmosql --detach --rm --tty --init --publish 31337:31337 --env TLS_ENABLED="1" --env GIZMOSQL_PASSWORD="gizmosql_password" --env PRINT_QUERIES="1" --volume "$(pwd)/data:/data" --pull always gizmodata/gizmosql:latest


### PR DESCRIPTION
- Add _convert_to_docker_path method to convert local file paths to Docker container paths
- Update _profile_column to use Docker paths when registering file views with GizmoSQL
- Add debug logging for file view registration to aid troubleshooting
- Update table_sleuth.toml with placeholder credentials and improved Docker run command
- GizmoSQL runs in Docker with /data mounted to ./data, requiring path conversion for profiling to work correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Converts local data paths to Docker container paths for GizmoSQL profiling and updates GizmoSQL config placeholders and run command.
> 
> - **TUI / Profiling**:
>   - Add `TableSleuthApp._convert_to_docker_path` to map `data/...` to `/data/...`.
>   - Use Docker-mapped path when calling `self._profiler.register_file_view(...)` in `_profile_column`.
>   - Add debug log for registered file view path.
> - **Config (`table_sleuth.toml`)**:
>   - Replace GizmoSQL `username`/`password` with placeholders.
>   - Update `docker run` example with TLS, password env, query logging, and image name `gizmodata/gizmosql:latest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 762f9f2df02a775d502a295b913edd8a81d29398. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->