### PR TITLE
Add data view to iceberg option

### DIFF
--- a/src/table_sleuth/tui/views/iceberg_view.py
+++ b/src/table_sleuth/tui/views/iceberg_view.py
@@ -32,6 +32,7 @@ from table_sleuth.services.snapshot_performance_analyzer import (
     SnapshotPerformanceAnalyzer,
 )
 from table_sleuth.services.snapshot_test_manager import SnapshotTestManager
+from table_sleuth.tui.views.data_sample_view import DataSampleView
 from table_sleuth.tui.views.snapshot_comparison_view import (
     PerformanceTestView,
     SnapshotComparisonView,
@@ -377,6 +378,9 @@ class IcebergView(Screen):
                     with TabPane("Properties", id="properties-tab"):
                         yield SnapshotPropertiesView(id="properties-view")
 
+                    with TabPane("Data Sample", id="data-sample-tab"):
+                        yield DataSampleView(id="data-sample-view")
+
                     with TabPane("Compare", id="compare-tab", disabled=True):
                         yield SnapshotComparisonView(id="comparison-view")
 
@@ -562,6 +566,34 @@ class IcebergView(Screen):
         # Update properties
         properties = self.query_one("#properties-view", SnapshotPropertiesView)
         properties.update_snapshot(self._selected_snapshot)
+
+        # Update data sample view with first data file
+        data_sample = self.query_one("#data-sample-view", DataSampleView)
+        if self._selected_details.data_files:
+            # Get the first data file for sampling
+            first_file = self._selected_details.data_files[0]
+            file_path = first_file["file_path"]
+
+            # Load the file info using the parquet inspector
+            try:
+                from pathlib import Path
+
+                from table_sleuth.services.parquet_service import ParquetInspector
+
+                # Ensure the file exists
+                if not Path(file_path).exists():
+                    logger.warning(f"Data file not found: {file_path}")
+                    data_sample.clear()
+                    return
+
+                parquet_inspector = ParquetInspector()
+                file_info = parquet_inspector.inspect_file(file_path)
+                data_sample.update_file_info(file_info)
+            except Exception as e:
+                logger.error(f"Failed to load data sample from {file_path}: {e}", exc_info=True)
+                data_sample.clear()
+        else:
+            data_sample.clear()
 
     def action_refresh(self) -> None:
         """Refresh the snapshot list."""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Data Sample tab that inspects the first snapshot data file via ParquetInspector and displays it in `DataSampleView`.
> 
> - **TUI — Iceberg View (`src/table_sleuth/tui/views/iceberg_view.py`)**:
>   - **New Tab**: Adds `Data Sample` tab (`DataSampleView`) to the detail panel.
>   - **Auto-loading Sample**: On snapshot selection, loads the first `data_files` entry, validates path, inspects via `ParquetInspector.inspect_file`, and updates `DataSampleView`; clears view on errors or when no files exist.
>   - **Imports/UI wiring**: Imports `DataSampleView` and wires it into `_update_detail_views()` and tabbed layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c412eae05f426ac324eca78c27b1fcdb597e9a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->