### PR TITLE
Ec2 instance

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -1,0 +1,84 @@
+# AWS Deployment Resources
+
+This directory contains scripts for deploying TableSleuth to AWS EC2.
+
+## Configuration
+
+Before using the deployment scripts, create a configuration file:
+
+1. Copy the template:
+   ```bash
+   cp config.json.template config.json
+   ```
+
+2. Edit `config.json` with your specific values:
+   ```json
+   {
+     "ssh_allowed_cidr": "YOUR_IP_ADDRESS/32",
+     "s3tables_bucket_arn": "arn:aws:s3tables:REGION:ACCOUNT_ID:bucket/BUCKET_NAME",
+     "s3tables_table_arn": "arn:aws:s3tables:REGION:ACCOUNT_ID:bucket/BUCKET_NAME/table/*"
+   }
+   ```
+
+   - `ssh_allowed_cidr`: Your public IP address with /32 suffix for SSH access
+   - `s3tables_bucket_arn`: ARN of your S3 Tables bucket for Iceberg data
+   - `s3tables_table_arn`: ARN pattern for tables in your S3 Tables bucket
+
+## Usage
+
+### Create Environment
+
+```bash
+# Dry run to see what would be created
+python tablesleuth_create_env.py --dry-run
+
+# Create the environment
+python tablesleuth_create_env.py
+
+# Use custom config file
+python tablesleuth_create_env.py --config /path/to/config.json
+```
+
+### Teardown Environment
+
+```bash
+# Dry run to see what would be destroyed
+python tablesleuth_teardown_env.py --dry-run
+
+# Destroy the environment
+python tablesleuth_teardown_env.py
+```
+
+## Security Notes
+
+- The `config.json` file is git-ignored to prevent committing sensitive information
+- SSH access is restricted to the IP address specified in `ssh_allowed_cidr`
+- The EC2 instance has IAM permissions for S3 and S3 Tables access only
+- Private SSH keys (*.pem) are also git-ignored
+
+## What Gets Created
+
+- VPC with public subnet and internet gateway
+- Security group allowing SSH from your IP only
+- IAM role with S3 and S3 Tables permissions
+- EC2 Spot instance with Python 3.13.9, git, awscli, GizmoSQL CLI
+- TableSleuth repository cloned and dependencies installed
+- TLS certificates for DuckDB server in `~/.certs`
+
+## Using S3 Tables on EC2
+
+Once deployed, the EC2 instance can access AWS S3 Tables directly:
+
+```bash
+# SSH to instance
+ssh -i tablesleuth-ssh-key.pem ec2-user@<instance-ip>
+
+# Activate environment
+cd ~/Code/TableSleuth
+source .venv/bin/activate
+
+# Inspect S3 Tables using ARN
+table-sleuth inspect "arn:aws:s3tables:us-east-2:835323357340:bucket/tpch-sf100/table/tpch.customer"
+```
+
+See [../docs/s3_tables_guide.md](../docs/s3_tables_guide.md) for more details.

--- a/resources/tablesleuth_create_env.py
+++ b/resources/tablesleuth_create_env.py
@@ -605,6 +605,75 @@ EOF
 
 chmod +x /usr/local/bin/install_python_3_13_9.sh
 /usr/local/bin/install_python_3_13_9.sh > /var/log/install_python_3_13_9.log 2>&1
+
+# Generate TLS certificates for DuckDB server
+cat << 'CERTEOF' >/usr/local/bin/gen-certs.sh
+#!/bin/bash
+set -eux
+
+# Ensure OpenSSL is installed
+if ! command -v openssl &> /dev/null; then
+    echo "Error: OpenSSL is not installed."
+    exit 1
+fi
+
+CERT_DIR="${1:-$HOME/.certs}"
+mkdir -p "$CERT_DIR"
+cd "$CERT_DIR"
+
+SUBJECT_ALT_NAME="DNS:$(hostname),DNS:host.docker.internal,DNS:localhost,DNS:example.com,DNS:another.example.com,IP:127.0.0.1"
+
+# Generate Root CA key and certificate
+openssl genrsa -out root-ca.key 4096
+chmod 600 root-ca.key
+
+openssl req -x509 -new -nodes \
+        -subj "/C=US/ST=CA/O=MyOrg, Inc./CN=Test CA" \
+        -key root-ca.key -sha256 -days 10000 \
+        -out root-ca.pem -extensions v3_ca
+
+# Generate user certificates
+for i in 0 1; do
+    openssl genrsa -out cert${i}.key 4096
+    chmod 600 cert${i}.key
+
+    openssl req -new -sha256 -key cert${i}.key \
+        -subj "/C=US/ST=CA/O=MyOrg, Inc./CN=localhost" \
+        -config <(echo "[req]
+distinguished_name=req_distinguished_name
+[req_distinguished_name]
+[SAN]
+subjectAltName=${SUBJECT_ALT_NAME}") \
+        -out cert${i}.csr
+
+    cat > v3_usr.cnf <<EOF
+[ v3_usr_extensions ]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = ${SUBJECT_ALT_NAME}
+EOF
+
+    openssl x509 -req -in cert${i}.csr -CA root-ca.pem -CAkey root-ca.key -CAcreateserial \
+        -out cert${i}.pem -days 10000 -sha256 -extfile v3_usr.cnf -extensions v3_usr_extensions
+
+    # Convert to PKCS#1 for Java
+    openssl pkcs8 -in cert${i}.key -topk8 -nocrypt > cert${i}.pkcs1
+done
+
+# Clean up intermediate files
+rm -f *.csr v3_usr.cnf
+
+echo "Certificates generated successfully in $CERT_DIR!"
+ls -lh "$CERT_DIR"
+CERTEOF
+
+chmod +x /usr/local/bin/gen-certs.sh
+
+echo "Generating TLS certificates for DuckDB server..."
+su - ec2-user -c '/usr/local/bin/gen-certs.sh /home/ec2-user/.certs' > /var/log/gen-certs.log 2>&1
+
+echo "Setup complete: Python, GizmoSQL, TableSleuth, and TLS certificates are ready."
 """
 
     instance_market_options = {

--- a/resources/tablesleuth_teardown_env.py
+++ b/resources/tablesleuth_teardown_env.py
@@ -154,6 +154,18 @@ def delete_vpc(ec2, vpc_id):
 
 
 def cleanup_iam(iam):
+    # Delete inline S3Tables policy from role
+    try:
+        iam.delete_role_policy(
+            RoleName=IAM_ROLE_NAME,
+            PolicyName="tablesleuth-s3tables-access",
+        )
+        print(f"Deleted inline S3Tables policy from role {IAM_ROLE_NAME}")
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code != "NoSuchEntity":
+            print(f"Warning: delete_role_policy failed: {e}")
+
     # Detach S3 policy from role
     try:
         iam.detach_role_policy(

--- a/src/table_sleuth/services/formats/iceberg.py
+++ b/src/table_sleuth/services/formats/iceberg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 from typing import Optional
 from urllib.parse import unquote, urlparse
@@ -13,10 +14,41 @@ from .base import TableFormatAdapter
 
 
 class IcebergAdapter(TableFormatAdapter):
-    """Apache Iceberg adapter using PyIceberg."""
+    """Apache Iceberg adapter using PyIceberg.
+
+    Supports multiple catalog types:
+    - Local SQL catalogs
+    - AWS S3 Tables via Glue catalog
+    - Direct metadata file paths
+    """
+
+    # S3 Tables ARN pattern: arn:aws:s3tables:region:account:bucket/bucket-name/table/namespace.table
+    S3_TABLES_ARN_PATTERN = re.compile(
+        r"arn:aws:s3tables:(?P<region>[^:]+):(?P<account>\d+):"
+        r"bucket/(?P<bucket>[^/]+)/table/(?P<table>.+)"
+    )
 
     def __init__(self, default_catalog: Optional[str] = None) -> None:
         self._default_catalog = default_catalog
+
+    def _parse_s3_tables_arn(self, arn: str) -> tuple[str, str] | None:
+        """Parse S3 Tables ARN into catalog name and table identifier.
+
+        Args:
+            arn: S3 Tables ARN (e.g., arn:aws:s3tables:us-east-2:123456:bucket/my-bucket/table/db.table)
+
+        Returns:
+            Tuple of (catalog_name, table_identifier) or None if not an S3 Tables ARN
+        """
+        match = self.S3_TABLES_ARN_PATTERN.match(arn)
+        if not match:
+            return None
+
+        # Extract table identifier (namespace.table)
+        table_identifier = match.group("table")
+
+        # Use s3tables catalog (configured in .pyiceberg.yaml)
+        return ("s3tables", table_identifier)
 
     def _file_uri_to_path(self, uri: str) -> str:
         """Convert file:// URI to local file path.
@@ -53,7 +85,24 @@ class IcebergAdapter(TableFormatAdapter):
         return StaticTable.from_metadata(identifier)
 
     def open_table(self, identifier: str, catalog_name: Optional[str] = None) -> TableHandle:
-        if catalog_name:
+        """Open an Iceberg table from various sources.
+
+        Args:
+            identifier: Can be:
+                - Table identifier (e.g., "db.table") when using catalog_name
+                - S3 Tables ARN (e.g., "arn:aws:s3tables:region:account:bucket/name/table/db.table")
+                - Path to metadata.json file
+            catalog_name: Optional catalog name to use
+
+        Returns:
+            TableHandle wrapping the PyIceberg Table
+        """
+        # Check if identifier is an S3 Tables ARN
+        s3_tables_info = self._parse_s3_tables_arn(identifier)
+        if s3_tables_info:
+            catalog_name, table_identifier = s3_tables_info
+            table = self._open_via_catalog(table_identifier, catalog_name)
+        elif catalog_name:
             table = self._open_via_catalog(identifier, catalog_name)
         elif self._default_catalog:
             table = self._open_via_catalog(identifier, self._default_catalog)

--- a/tests/test_s3_tables_arn.py
+++ b/tests/test_s3_tables_arn.py
@@ -1,0 +1,101 @@
+"""Tests for AWS S3 Tables ARN parsing."""
+
+import pytest
+
+from table_sleuth.services.formats.iceberg import IcebergAdapter
+
+
+class TestS3TablesARN:
+    """Test S3 Tables ARN parsing and handling."""
+
+    def test_parse_valid_s3_tables_arn(self):
+        """Test parsing a valid S3 Tables ARN."""
+        adapter = IcebergAdapter()
+
+        arn = "arn:aws:s3tables:us-east-2:835323357340:bucket/tpch-sf100/table/tpch.lineitem"
+        result = adapter._parse_s3_tables_arn(arn)
+
+        assert result is not None
+        catalog_name, table_identifier = result
+        assert catalog_name == "s3tables"
+        assert table_identifier == "tpch.lineitem"
+
+    def test_parse_s3_tables_arn_with_nested_namespace(self):
+        """Test parsing S3 Tables ARN with multi-level namespace."""
+        adapter = IcebergAdapter()
+
+        arn = "arn:aws:s3tables:eu-west-1:123456789012:bucket/my-bucket/table/db.schema.table"
+        result = adapter._parse_s3_tables_arn(arn)
+
+        assert result is not None
+        catalog_name, table_identifier = result
+        assert catalog_name == "s3tables"
+        assert table_identifier == "db.schema.table"
+
+    def test_parse_s3_tables_arn_different_region(self):
+        """Test parsing S3 Tables ARN from different regions."""
+        adapter = IcebergAdapter()
+
+        test_cases = [
+            (
+                "arn:aws:s3tables:us-west-2:111111111111:bucket/west-bucket/table/db.table",
+                "db.table",
+            ),
+            (
+                "arn:aws:s3tables:ap-southeast-1:222222222222:bucket/asia-bucket/table/prod.users",
+                "prod.users",
+            ),
+            (
+                "arn:aws:s3tables:eu-central-1:333333333333:bucket/eu-bucket/table/analytics.events",
+                "analytics.events",
+            ),
+        ]
+
+        for arn, expected_table in test_cases:
+            result = adapter._parse_s3_tables_arn(arn)
+            assert result is not None
+            catalog_name, table_identifier = result
+            assert catalog_name == "s3tables"
+            assert table_identifier == expected_table
+
+    def test_parse_invalid_arn_returns_none(self):
+        """Test that invalid ARNs return None."""
+        adapter = IcebergAdapter()
+
+        invalid_arns = [
+            "not-an-arn",
+            "arn:aws:s3:us-east-1:123456789012:bucket/my-bucket",  # S3 bucket, not S3 Tables
+            "arn:aws:glue:us-east-1:123456789012:table/db/table",  # Glue table
+            "arn:aws:s3tables:us-east-1:123456789012:invalid",  # Missing bucket/table parts
+            "",
+            "db.table",  # Regular table identifier
+        ]
+
+        for arn in invalid_arns:
+            result = adapter._parse_s3_tables_arn(arn)
+            assert result is None, f"Expected None for invalid ARN: {arn}"
+
+    def test_parse_s3_tables_arn_with_special_characters(self):
+        """Test parsing ARN with special characters in names."""
+        adapter = IcebergAdapter()
+
+        arn = "arn:aws:s3tables:us-east-2:123456789012:bucket/my-bucket-123/table/db_prod.table_v2"
+        result = adapter._parse_s3_tables_arn(arn)
+
+        assert result is not None
+        catalog_name, table_identifier = result
+        assert catalog_name == "s3tables"
+        assert table_identifier == "db_prod.table_v2"
+
+    def test_arn_pattern_regex(self):
+        """Test the ARN regex pattern directly."""
+        adapter = IcebergAdapter()
+
+        valid_arn = "arn:aws:s3tables:us-east-2:835323357340:bucket/tpch-sf100/table/tpch.lineitem"
+        match = adapter.S3_TABLES_ARN_PATTERN.match(valid_arn)
+
+        assert match is not None
+        assert match.group("region") == "us-east-2"
+        assert match.group("account") == "835323357340"
+        assert match.group("bucket") == "tpch-sf100"
+        assert match.group("table") == "tpch.lineitem"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds AWS EC2 deploy/teardown scripts and enables loading Iceberg tables via AWS S3 Tables ARNs.
> 
> - **Resources (AWS EC2 deployment)**:
>   - Add `resources/tablesleuth_create_env.py` to provision VPC, subnet, IGW, route table, SSH-only SG, IAM role/profile (S3 + S3 Tables access), key pair, and Spot EC2 instance.
>   - Instance bootstrap installs Python `3.13.9`, git, awscli, GizmoSQL CLI, clones `TableSleuth`, sets up `.venv`, and generates TLS certs in `~/.certs`.
>   - Add `resources/tablesleuth_teardown_env.py` to terminate instances and delete network/IAM resources.
>   - Add `resources/README.md` with config, usage, and security notes.
> - **Iceberg adapter** (`src/table_sleuth/services/formats/iceberg.py`):
>   - Add S3 Tables ARN regex parsing and support in `open_table` to load via `s3tables` catalog.
> - **Tests**:
>   - Add `tests/test_s3_tables_arn.py` covering ARN parsing across regions/namespaces and invalid cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b61ba3792f1f8174133b25e2e4b8f2bf555d68d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->