### PR TITLE
feat(aws): add S3 Tables support with boto3 integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,8 @@ dmypy.json
 Thumbs.db
 
 # Project specific
-#resources/config.json
+resources/config.json
+*.pem
 input/
 .kiro/
 .chroma/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "rich>=13.0.0",
     "sqlalchemy>=2.0.0",
     "duckdb>=1.1.0",
+    "boto3>=1.35.0",
 ]
 
 [project.optional-dependencies]

--- a/resources/config.json.template
+++ b/resources/config.json.template
@@ -1,0 +1,5 @@
+{
+  "ssh_allowed_cidr": "YOUR_IP_ADDRESS/32",
+  "s3tables_bucket_arn": "arn:aws:s3tables:REGION:ACCOUNT_ID:bucket/BUCKET_NAME",
+  "s3tables_table_arn": "arn:aws:s3tables:REGION:ACCOUNT_ID:bucket/BUCKET_NAME/table/*"
+}

--- a/uv.lock
+++ b/uv.lock
@@ -211,6 +211,20 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.40.70"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/12/d5ac34e0536e1914dde28245f014a635056dde0427f6efa09f104d7999f4/boto3-1.40.70.tar.gz", hash = "sha256:191443707b391232ed15676bf6bba7e53caec1e71aafa12ccad2e825c5ee15cc", size = 111638, upload-time = "2025-11-10T20:29:15.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/cf/e24d08b37cd318754a8e94906c8b34b88676899aad1907ff6942311f13c4/boto3-1.40.70-py3-none-any.whl", hash = "sha256:e8c2f4f4cb36297270f1023ebe5b100333e0e88ab6457a9687d80143d2e15bf9", size = 139358, upload-time = "2025-11-10T20:29:13.512Z" },
+]
+
+[[package]]
 name = "botocore"
 version = "1.40.70"
 source = { registry = "https://pypi.org/simple" }
@@ -1456,6 +1470,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1521,6 +1547,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "adbc-driver-flightsql" },
+    { name = "boto3" },
     { name = "click" },
     { name = "duckdb" },
     { name = "pandas" },
@@ -1549,6 +1576,7 @@ dev = [
 requires-dist = [
     { name = "adbc-driver-flightsql", specifier = ">=1.7.0" },
     { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=1.7.0,<2.0.0" },
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "duckdb", specifier = ">=1.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0,<2.0.0" },


### PR DESCRIPTION
- Add boto3 dependency (>=1.35.0) for AWS S3 Tables API access
- Create config.json.template with S3 Tables ARN configuration examples
- Update .gitignore to exclude config.json and .pem files for security
- Add s3transfer dependency as transitive boto3 dependency
- Update uv.lock with boto3 and s3transfer package versions
- Enable AWS S3 Tables bucket and table ARN configuration for data access

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add AWS S3 Tables support by adding `boto3`, providing a config template with S3 Tables ARNs, and updating ignore rules for config and key files.
> 
> - **Dependencies**:
>   - Add `boto3>=1.35.0` in `pyproject.toml` and lock; include transitive `s3transfer`.
> - **Configuration**:
>   - Add `resources/config.json.template` with `ssh_allowed_cidr`, `s3tables_bucket_arn`, and `s3tables_table_arn` examples.
> - **Repo hygiene**:
>   - Update `.gitignore` to ignore `resources/config.json` and `*.pem`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1de937b44b5cbe464638dbf46a50213376f2a36d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->