### PR TITLE
feat(iceberg): add S3 Tables ARN support and AWS CLI v2 bootstrap

### DIFF
--- a/resources/tablesleuth_create_env.py
+++ b/resources/tablesleuth_create_env.py
@@ -615,6 +615,13 @@ echo "Creating venv at /home/ec2-user/py313-venv..."
 "${{PY_BIN}}" -m venv /home/ec2-user/py313-venv
 chown -R ec2-user:ec2-user /home/ec2-user/py313-venv
 
+echo "Installing AWS CLI v2..."
+cd /tmp
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+unzip -o awscliv2.zip
+./aws/install
+rm -rf aws awscliv2.zip
+
 echo "Installing GizmoSQL CLI..."
 cd /tmp
 wget https://github.com/gizmodata/gizmosql/releases/download/v1.12.13/gizmosql_cli_linux_amd64.zip
@@ -625,7 +632,16 @@ echo "Cloning TableSleuth repo for ec2-user..."
 su - ec2-user -c 'mkdir -p ~/Code && git clone https://github.com/jamesbconner/TableSleuth.git ~/Code/TableSleuth || true'
 
 echo "Creating .venv in ~/Code/TableSleuth and installing uv + project dependencies..."
-su - ec2-user -c 'cd ~/Code/TableSleuth && python -m venv .venv && . .venv/bin/activate && pip install uv && uv sync'
+su - ec2-user -c 'cd ~/Code/TableSleuth && python -m venv .venv && . .venv/bin/activate && pip install uv && uv sync --all-extras'
+
+echo "Configuring PyIceberg for S3 Tables..."
+cat > /home/ec2-user/.pyiceberg.yaml <<PYICEEOF
+catalog:
+  s3tables:
+    type: glue
+PYICEEOF
+
+chown ec2-user:ec2-user /home/ec2-user/.pyiceberg.yaml
 
 echo "Python ${{PY_VERSION}}, pip, venv, virtualenv, git, awscli, GizmoSQL, and TableSleuth are installed and bootstrapped."
 EOF

--- a/src/table_sleuth/cli.py
+++ b/src/table_sleuth/cli.py
@@ -87,7 +87,27 @@ def inspect(path: str, catalog_name: str | None, verbose: bool) -> None:
     table_handle: TableHandle | None = None
 
     try:
-        if catalog_name:
+        # Check if it's an S3 Tables ARN first
+        if path.startswith("arn:aws:s3tables:"):
+            click.echo(f"Loading S3 Tables Iceberg table: {path}")
+
+            # Open table using ARN (adapter will parse it)
+            table_handle = adapter.open_table(path)
+
+            # Discover files from table
+            discovery = FileDiscoveryService(iceberg_adapter=adapter)
+            # Extract table identifier from ARN for discovery
+            arn_info = adapter._parse_s3_tables_arn(path)
+            if arn_info:
+                catalog, table_id = arn_info
+                files = discovery.discover_from_table(table_id, catalog)
+            else:
+                click.echo(f"Error: Invalid S3 Tables ARN format: {path}", err=True)
+                sys.exit(1)
+
+            click.echo(f"Found {len(files)} data files in table")
+
+        elif catalog_name:
             # Treat as Iceberg table identifier
             click.echo(f"Loading Iceberg table: {path} (catalog: {catalog_name})")
 

--- a/src/table_sleuth/services/formats/iceberg.py
+++ b/src/table_sleuth/services/formats/iceberg.py
@@ -23,6 +23,7 @@ class IcebergAdapter(TableFormatAdapter):
     """
 
     # S3 Tables ARN pattern: arn:aws:s3tables:region:account:bucket/bucket-name/table/namespace.table
+    # Also supports UUID format: arn:aws:s3tables:region:account:bucket/bucket-name/table/uuid
     S3_TABLES_ARN_PATTERN = re.compile(
         r"arn:aws:s3tables:(?P<region>[^:]+):(?P<account>\d+):"
         r"bucket/(?P<bucket>[^/]+)/table/(?P<table>.+)"


### PR DESCRIPTION
- Add S3 Tables ARN parsing and table loading in CLI inspect command
- Support both namespace.table and UUID formats in S3 Tables ARN pattern
- Implement ARN validation and file discovery from S3 Tables Iceberg tables
- Add AWS CLI v2 installation to EC2 bootstrap script
- Create PyIceberg configuration for S3 Tables Glue catalog on EC2 setup
- Update project dependency installation to include all extras (--all-extras)
- Enable direct S3 Tables ARN inspection without requiring catalog name parameter
- Improves user experience by supporting native AWS S3 Tables ARN format for table access

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add S3 Tables ARN-based table loading to the inspect CLI and bootstrap AWS CLI v2 plus PyIceberg Glue config on EC2; install project deps with all extras.
> 
> - **CLI (inspect)**:
>   - Support loading Iceberg tables via S3 Tables ARNs (`arn:aws:s3tables:...`).
>   - Parse ARN, open table via `IcebergAdapter`, and discover files without requiring `--catalog`.
> - **Iceberg Adapter**:
>   - Define `S3_TABLES_ARN_PATTERN` (supports namespace.table and UUID forms) and ARN parsing helper.
> - **EC2 Bootstrap (`resources/tablesleuth_create_env.py`)**:
>   - Install AWS CLI v2.
>   - Create `.pyiceberg.yaml` with Glue-based `s3tables` catalog.
>   - Install project dependencies with `uv sync --all-extras`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22240770839a160aad42a4ec70a2cd14a78b71b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->