### PR TITLE
fix(iceberg): preserve S3 URIs in file path conversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "table-sleuth"
-version = "0.2.0"
+version = "0.2.1"
 description = "Table Sleuth - a Textual TUI for Open Table Format forensics (OTF) with data profiling."
 readme = "README.md"
 requires-python = ">=3.13,<3.15"

--- a/src/table_sleuth/services/formats/iceberg.py
+++ b/src/table_sleuth/services/formats/iceberg.py
@@ -52,16 +52,22 @@ class IcebergAdapter(TableFormatAdapter):
         return ("s3tables", table_identifier)
 
     def _file_uri_to_path(self, uri: str) -> str:
-        """Convert file:// URI to local file path.
+        """Convert file:// URI to local file path, preserve S3 URIs.
 
         Handles both Unix (file:///path) and Windows (file:///C:/path) URIs correctly.
+        S3 URIs (s3://bucket/path) are returned unchanged.
 
         Args:
             uri: File URI string
 
         Returns:
-            Local file path
+            Local file path or S3 URI
         """
+        # Preserve S3 URIs unchanged
+        if uri.startswith("s3://") or uri.startswith("s3a://"):
+            return uri
+
+        # Only convert file:// URIs
         if not uri.startswith("file://"):
             return uri
 

--- a/uv.lock
+++ b/uv.lock
@@ -1552,7 +1552,7 @@ wheels = [
 
 [[package]]
 name = "table-sleuth"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "adbc-driver-flightsql" },


### PR DESCRIPTION
- Update version to 0.2.1 in pyproject.toml and uv.lock
- Modify _file_uri_to_path() to preserve S3 URIs (s3:// and s3a://) unchanged
- Add early return for S3 URIs before attempting file:// URI conversion
- Update docstring to clarify that S3 URIs are returned unchanged
- Prevent incorrect path conversion for cloud-based Iceberg table locations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves `s3://` and `s3a://` URIs in Iceberg file path conversion and bumps version to `0.2.1`.
> 
> - **Iceberg Adapter (`src/table_sleuth/services/formats/iceberg.py`)**:
>   - Update `_file_uri_to_path` to return `s3://` and `s3a://` URIs unchanged; refine docstring and add early return.
> - **Versioning**:
>   - Bump project version to `0.2.1` in `pyproject.toml` and `uv.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee99e082bcdc0beeff61298043942d927e7241b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->