### PR TITLE
feat(iceberg): pass catalog name to snapshot test manager

### DIFF
--- a/src/table_sleuth/cli.py
+++ b/src/table_sleuth/cli.py
@@ -330,6 +330,7 @@ def iceberg_viewer(
                         table_info=table_info,
                         metadata_service=metadata_service,
                         profiler=profiler,
+                        catalog_name=catalog_name,
                     )
                 )
 

--- a/src/table_sleuth/tui/views/iceberg_view.py
+++ b/src/table_sleuth/tui/views/iceberg_view.py
@@ -299,6 +299,7 @@ class IcebergView(Screen):
         table_info: IcebergTableInfo,
         metadata_service: IcebergMetadataService,
         profiler: ProfilingBackend | None = None,
+        catalog_name: str | None = None,
         *,
         name: str | None = None,
         id: str | None = None,
@@ -310,6 +311,7 @@ class IcebergView(Screen):
             table_info: Iceberg table information
             metadata_service: Service for loading metadata
             profiler: Optional profiling backend for performance testing
+            catalog_name: Catalog name for snapshot registration (defaults to "local")
             name: Screen name
             id: Screen ID
             classes: CSS classes
@@ -318,6 +320,7 @@ class IcebergView(Screen):
         self._table_info = table_info
         self._metadata_service = metadata_service
         self._profiler = profiler
+        self._catalog_name = catalog_name or "local"
 
         # Initialize managers
         self._test_manager: SnapshotTestManager | None = None
@@ -657,7 +660,7 @@ class IcebergView(Screen):
         try:
             # Initialize test manager if needed
             if self._test_manager is None:
-                self._test_manager = SnapshotTestManager(catalog_name="local")
+                self._test_manager = SnapshotTestManager(catalog_name=self._catalog_name)
                 self._test_manager.ensure_snapshot_namespace()
 
             # Register both snapshots


### PR DESCRIPTION
- Add catalog_name parameter to IcebergView initialization
- Pass catalog_name from CLI to IcebergView constructor
- Use instance catalog_name in SnapshotTestManager initialization
- Default to "local" catalog when catalog_name is not provided
- Enable flexible catalog configuration for snapshot registration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Thread `catalog_name` from CLI into `IcebergView` and use it to initialize `SnapshotTestManager`, defaulting to "local".
> 
> - **Iceberg Viewer TUI (`IcebergView`)**:
>   - Add optional `catalog_name` param (defaults to `"local"`).
>   - Use instance `catalog_name` when creating `SnapshotTestManager` (replaces hardcoded `"local"`).
> - **CLI (`iceberg_viewer`)**:
>   - Pass `catalog_name` through to `IcebergView` constructor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63ca948cb6210d5525ed1e560b9a9fa0e8c27876. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->