### PR TITLE
docs: update GizmoSQL configuration to use TLS and port 31337

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ pytest tests/test_parquet_inspector.py
 
 # Run integration tests (requires local GizmoSQL server)
 # Set TEST_GIZMOSQL_URI environment variable first
-export TEST_GIZMOSQL_URI="grpc://localhost:10501"
+export TEST_GIZMOSQL_URI="grpc+tls://localhost:31337"
 pytest -m integration
 ```
 
@@ -407,7 +407,7 @@ pytest tests/test_parquet_inspector.py
 pytest tests/test_parquet_inspector.py::test_inspect_file_basic_metadata
 
 # Run integration tests only (requires local GizmoSQL)
-export TEST_GIZMOSQL_URI="grpc://localhost:10501"
+export TEST_GIZMOSQL_URI="grpc+tls://localhost:31337"
 pytest -m integration
 
 # Run with verbose output

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -111,8 +111,10 @@ curl -L https://github.com/gizmodata/gizmosql/releases/download/v1.12.10/gizmosq
 #### Start GizmoSQL Server
 
 ```bash
-GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 10501 --print-queries
+gizmosql_server -P gizmosql_password -Q -T ~/.certs/cert0.pem ~/.certs/cert0.key
 ```
+
+(Default port is 31337, -Q enables query printing, -T enables TLS)
 
 #### Configure Connection
 
@@ -120,10 +122,10 @@ Create `table_sleuth.toml`:
 
 ```toml
 [gizmosql]
-uri = "grpc://localhost:10501"
+uri = "grpc+tls://localhost:31337"
 username = "gizmosql_username"
 password = "gizmosql_password"
-tls_skip_verify = false
+tls_skip_verify = true
 ```
 
 #### Profile a Column
@@ -266,10 +268,10 @@ Create `table_sleuth.toml`:
 default = "local"
 
 [gizmosql]
-uri = "grpc://localhost:10501"
+uri = "grpc+tls://localhost:31337"
 username = "gizmosql_username"
 password = "gizmosql_password"
-tls_skip_verify = false
+tls_skip_verify = true
 ```
 
 ### Environment Variables
@@ -278,7 +280,7 @@ Override configuration with environment variables:
 
 ```bash
 export TABLE_SLEUTH_CATALOG_NAME="local"
-export TABLE_SLEUTH_GIZMO_URI="grpc://localhost:10501"
+export TABLE_SLEUTH_GIZMO_URI="grpc+tls://localhost:31337"
 export TABLE_SLEUTH_GIZMO_USERNAME="gizmosql_username"
 export TABLE_SLEUTH_GIZMO_PASSWORD="gizmosql_password"
 ```
@@ -309,13 +311,13 @@ ls -la data/warehouse/
 
 ```bash
 # Check server is running
-curl http://localhost:10501/health
+curl http://localhost:31337/health
 
 # Check port is accessible
-nc -zv localhost 10501
+nc -zv localhost 31337
 
 # Restart server if needed
-GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 10501 --print-queries
+gizmosql_server -P gizmosql_password -Q -T ~/.certs/cert0.pem ~/.certs/cert0.key
 ```
 
 ### Slow Performance

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Create `table_sleuth.toml` in your project directory or `~/.config/table_sleuth.
 default = "local"
 
 [gizmosql]
-uri = "grpc://localhost:10501"
+uri = "grpc+tls://localhost:31337"
 username = "gizmosql_username"
 password = "gizmosql_password"
 ```
@@ -205,18 +205,20 @@ curl -L https://github.com/gizmodata/gizmosql/releases/download/v1.12.10/gizmosq
 ### Start Server
 
 ```bash
-GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 10501 --print-queries
+gizmosql_server -P gizmosql_password -Q -T ~/.certs/cert0.pem ~/.certs/cert0.key
 ```
+
+(Default port is 31337, -Q enables query printing, -T enables TLS with self-signed certs)
 
 ### Configure
 
 Update `table_sleuth.toml`:
 ```toml
 [gizmosql]
-uri = "grpc://localhost:10501"
+uri = "grpc+tls://localhost:31337"
 username = "gizmosql_username"
 password = "gizmosql_password"
-tls_skip_verify = false
+tls_skip_verify = true
 ```
 
 See [docs/gizmosql-deployment.md](docs/gizmosql-deployment.md) for detailed setup instructions.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -532,7 +532,7 @@ Display comparison results
 default = "local"
 
 [gizmosql]
-uri = "grpc://localhost:10501"
+uri = "grpc+tls://localhost:31337"
 username = "gizmosql_username"
 password = "gizmosql_password"
 tls_skip_verify = false
@@ -591,7 +591,7 @@ class Config:
 │  └──────────────────────────────┘   │
 └─────────────────────────────────────┘
               │
-              │ gRPC (localhost:10501)
+              │ gRPC (localhost:31337)
               ▼
 ┌─────────────────────────────────────┐
 │   Local GizmoSQL Server             │
@@ -626,7 +626,7 @@ curl -L https://github.com/gizmodata/gizmosql/releases/download/v1.12.10/gizmosq
   | sudo unzip -o -d /usr/local/bin -
 
 # Start server
-GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 10501 --print-queries
+GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 31337 --print-queries
 ```
 
 ## Error Handling Strategy

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -477,7 +477,7 @@ def test_inspect_file_missing_statistics(parquet_file_no_stats):
 @pytest.mark.skipif(not GIZMOSQL_AVAILABLE, reason="TEST_GIZMOSQL_URI not set")
 def test_gizmosql_profiling_workflow(test_parquet_file):
     profiler = GizmoDuckDbProfiler(
-        uri="grpc://localhost:10501",
+        uri="grpc+tls://localhost:31337",
         username="gizmosql_username",
         password="gizmosql_password",
         tls_skip_verify=False,
@@ -571,12 +571,12 @@ def gizmosql_server():
     import subprocess
     try:
         result = subprocess.run(
-            ["curl", "-s", "http://localhost:10501/health"],
+            ["curl", "-s", "http://localhost:31337/health"],
             capture_output=True,
             timeout=2
         )
         if result.returncode == 0:
-            yield "grpc://localhost:10501"
+            yield "grpc+tls://localhost:31337"
         else:
             pytest.skip("GizmoSQL server not running")
     except Exception:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -48,7 +48,7 @@ Create a `table_sleuth.toml` file in your project directory or `~/.config/table_
 default = "local"
 
 [gizmosql]
-uri = "grpc://localhost:10501"
+uri = "grpc+tls://localhost:31337"
 username = "gizmosql_username"
 password = "gizmosql_password"
 tls_skip_verify = false
@@ -60,7 +60,7 @@ You can override configuration with environment variables:
 
 ```bash
 export TABLE_SLEUTH_CATALOG_NAME="local"
-export TABLE_SLEUTH_GIZMO_URI="grpc://localhost:10501"
+export TABLE_SLEUTH_GIZMO_URI="grpc+tls://localhost:31337"
 export TABLE_SLEUTH_GIZMO_USERNAME="gizmosql_username"
 export TABLE_SLEUTH_GIZMO_PASSWORD="gizmosql_password"
 ```
@@ -307,7 +307,7 @@ curl -L https://github.com/gizmodata/gizmosql/releases/download/v1.12.10/gizmosq
 Run in a terminal window:
 
 ```bash
-GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 10501 --print-queries
+GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 31337 --print-queries
 ```
 
 ### Configure Connection
@@ -316,7 +316,7 @@ Create or update `table_sleuth.toml`:
 
 ```toml
 [gizmosql]
-uri = "grpc://localhost:10501"
+uri = "grpc+tls://localhost:31337"
 username = "gizmosql_username"
 password = "gizmosql_password"
 tls_skip_verify = false
@@ -325,7 +325,7 @@ tls_skip_verify = false
 Or use environment variables:
 
 ```bash
-export TABLE_SLEUTH_GIZMO_URI="grpc://localhost:10501"
+export TABLE_SLEUTH_GIZMO_URI="grpc+tls://localhost:31337"
 export TABLE_SLEUTH_GIZMO_USERNAME="gizmosql_username"
 export TABLE_SLEUTH_GIZMO_PASSWORD="gizmosql_password"
 ```
@@ -350,19 +350,19 @@ export TABLE_SLEUTH_GIZMO_PASSWORD="gizmosql_password"
 **Server Not Running:**
 ```bash
 # Check if GizmoSQL is running
-curl http://localhost:10501/health
+curl http://localhost:31337/health
 
 # If not running, start it:
-GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 10501 --print-queries
+GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 31337 --print-queries
 ```
 
 **Connection Refused:**
 ```bash
 # Check port is accessible
-nc -zv localhost 10501
+nc -zv localhost 31337
 
 # Check firewall settings
-# Ensure port 10501 is not blocked
+# Ensure port 31337 is not blocked
 ```
 
 **Authentication Failed:**
@@ -393,7 +393,7 @@ uri = "grpc://localhost:10502"
 **Remote GizmoSQL:**
 ```toml
 [gizmosql]
-uri = "grpc://gizmosql.example.com:10501"
+uri = "grpc://gizmosql.example.com:31337"
 username = "your_username"
 password = "your_password"
 tls_skip_verify = false

--- a/docs/gizmosql-deployment.md
+++ b/docs/gizmosql-deployment.md
@@ -46,10 +46,10 @@ Edit `table_sleuth.toml`:
 
 ```toml
 [gizmosql]
-uri = "grpc://localhost:10501"
+uri = "grpc+tls://localhost:31337"
 username = "gizmosql_username"
 password = "gizmosql_password"
-tls_skip_verify = false
+tls_skip_verify = true
 ```
 
 **Important**: Do not configure `local_data_path` or `docker_data_path`. These are legacy settings for Docker deployments which are no longer recommended.
@@ -59,19 +59,20 @@ tls_skip_verify = false
 Run GizmoSQL in a terminal window:
 
 ```bash
-GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 10501 --print-queries
+gizmosql_server -P gizmosql_password -Q -T ~/.certs/cert0.pem ~/.certs/cert0.key
 ```
 
 **Options**:
-- `--port 10501`: Port to listen on (default: 10501)
-- `--print-queries`: Log all queries for debugging (optional)
-- `GIZMOSQL_PASSWORD`: Password for authentication (must match config)
+- Default port is 31337
+- `-P`: Password for authentication (must match config)
+- `-Q`: Print queries for debugging
+- `-T`: Enable TLS with certificate and key files
 
 ### 3. Verify Connection
 
 ```bash
 # Check if GizmoSQL is running
-curl http://localhost:10501/health
+curl http://localhost:31337/health
 
 # Or use Table Sleuth to test profiling
 table-sleuth inspect data/your-file.parquet
@@ -143,7 +144,7 @@ curl -L https://github.com/gizmodata/gizmosql/releases/download/v1.12.10/gizmosq
 **Solution**:
 1. Verify GizmoSQL is running:
    ```bash
-   curl http://localhost:10501/health
+   curl http://localhost:31337/health
    ```
 
 2. Check the password matches in both places:
@@ -151,14 +152,14 @@ curl -L https://github.com/gizmodata/gizmosql/releases/download/v1.12.10/gizmosq
    - Config file: `password = "gizmosql_password"`
 
 3. Verify the port matches:
-   - GizmoSQL: `--port 10501`
-   - Config: `uri = "grpc://localhost:10501"`
+   - GizmoSQL: `--port 31337`
+   - Config: `uri = "grpc+tls://localhost:31337"`
 
 **Problem**: "Profiling backend not available"
 
 **Solution**: This means GizmoSQL isn't running or isn't reachable. Check:
 1. GizmoSQL server is running (check terminal window)
-2. No firewall blocking port 10501
+2. No firewall blocking port 31337
 3. Configuration in `table_sleuth.toml` is correct
 
 ### Profiling Issues
@@ -218,7 +219,7 @@ You can override configuration via environment variables:
 
 ```bash
 # Connection settings
-export TABLE_SLEUTH_GIZMO_URI="grpc://localhost:10501"
+export TABLE_SLEUTH_GIZMO_URI="grpc+tls://localhost:31337"
 export TABLE_SLEUTH_GIZMO_USERNAME="gizmosql_username"
 export TABLE_SLEUTH_GIZMO_PASSWORD="gizmosql_password"
 
@@ -241,7 +242,7 @@ After=network.target
 Type=simple
 User=your-username
 Environment="GIZMOSQL_PASSWORD=gizmosql_password"
-ExecStart=/usr/local/bin/gizmosql_server --port 10501 --print-queries
+ExecStart=/usr/local/bin/gizmosql_server --port 31337 --print-queries
 Restart=on-failure
 
 [Install]
@@ -270,7 +271,7 @@ Create `~/Library/LaunchAgents/com.gizmodata.gizmosql.plist`:
     <array>
         <string>/usr/local/bin/gizmosql_server</string>
         <string>--port</string>
-        <string>10501</string>
+        <string>31337</string>
         <string>--print-queries</string>
     </array>
     <key>EnvironmentVariables</key>
@@ -302,12 +303,12 @@ launchctl start com.gizmodata.gizmosql
 
 ### Start GizmoSQL
 ```bash
-GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 10501 --print-queries
+GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 31337 --print-queries
 ```
 
 ### Check Status
 ```bash
-curl http://localhost:10501/health
+curl http://localhost:31337/health
 ```
 
 ### Stop GizmoSQL
@@ -321,5 +322,5 @@ pkill gizmosql_server
 ```bash
 # Logs are printed to stdout when using --print-queries
 # Redirect to file if needed:
-GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 10501 --print-queries > gizmosql.log 2>&1
+GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 31337 --print-queries > gizmosql.log 2>&1
 ```

--- a/src/table_sleuth/services/profiling/gizmo_duckdb.py
+++ b/src/table_sleuth/services/profiling/gizmo_duckdb.py
@@ -137,13 +137,24 @@ class GizmoDuckDbProfiler(ProfilingBackend):
         self._registered_catalogs: dict[str, str] = {}  # catalog_name -> catalog_path
 
     def _connect(self):
+        # Determine if we should use TLS based on URI scheme
+        # grpc:// = plain (no TLS), grpc+tls:// = TLS
+        use_tls = self._uri.startswith("grpc+tls://")
+
+        db_kwargs = {
+            "username": self._username,
+            "password": self._password,
+        }
+
+        # Only add TLS options if using TLS
+        if use_tls:
+            db_kwargs[DatabaseOptions.TLS_SKIP_VERIFY.value] = (
+                "true" if self._tls_skip_verify else "false"
+            )
+
         return flightsql.connect(
             uri=self._uri,
-            db_kwargs={
-                "username": self._username,
-                "password": self._password,
-                DatabaseOptions.TLS_SKIP_VERIFY.value: "true" if self._tls_skip_verify else "false",
-            },
+            db_kwargs=db_kwargs,
         )
 
     def register_snapshot_view(self, snapshot: SnapshotInfo) -> str:

--- a/src/table_sleuth/tui/app.py
+++ b/src/table_sleuth/tui/app.py
@@ -515,8 +515,8 @@ class TableSleuthApp(App):
             # Provide deployment-specific guidance
             error_msg = (
                 "GizmoSQL connection failed. Please ensure GizmoSQL is running.\n\n"
-                "Local GizmoSQL:\n"
-                "gizmosql --port 10501\n\n"
+                "Start GizmoSQL:\n"
+                "gizmosql_server -P gizmosql_password -Q -T ~/.certs/cert0.pem ~/.certs/cert0.key\n\n"
                 "Or install via: pip install gizmosql"
             )
 

--- a/table_sleuth.toml
+++ b/table_sleuth.toml
@@ -8,16 +8,17 @@ default = "local"
 # GizmoSQL connection settings for column profiling and Iceberg performance testing
 # GizmoSQL runs as a local process with direct filesystem access
 
-uri = "grpc://localhost:10501"
+uri = "grpc+tls://localhost:31337"
 username = "gizmosql_username"
 password = "gizmosql_password"
-tls_skip_verify = false
+tls_skip_verify = true
 
 # Note: Do NOT configure local_data_path or docker_data_path
 # These are legacy settings for Docker deployments which are no longer recommended
 
 # To start GizmoSQL:
-# GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --port 10501 --print-queries
+# gizmosql_server -P gizmosql_password -Q -T ~/.certs/cert0.pem ~/.certs/cert0.key
+# (Default port is 31337, -Q enables query printing, -T enables TLS with self-signed certs)
 #
 # Installation:
 # macOS (ARM64): curl -L https://github.com/gizmodata/gizmosql/releases/download/v1.12.10/gizmosql_cli_macos_arm64.zip | sudo unzip -o -d /usr/local/bin -

--- a/tests/test_gizmo_profiler_config.py
+++ b/tests/test_gizmo_profiler_config.py
@@ -66,7 +66,7 @@ class TestGizmoProfilerConfiguration:
     def test_register_file_view_without_prefix(self):
         """Test that register_file_view handles paths without file:// prefix."""
         profiler = GizmoDuckDbProfiler(
-            uri="grpc://localhost:10501",
+            uri="grpc+tls://localhost:31337",
             username="test_user",
             password="test_pass",
         )
@@ -87,7 +87,7 @@ class TestGizmoProfilerConfiguration:
     def test_register_file_view_auto_generates_name(self):
         """Test that register_file_view auto-generates view name when not provided."""
         profiler = GizmoDuckDbProfiler(
-            uri="grpc://localhost:10501",
+            uri="grpc+tls://localhost:31337",
             username="test_user",
             password="test_pass",
         )
@@ -102,7 +102,7 @@ class TestGizmoProfilerConfiguration:
     def test_register_file_view_empty_paths_raises(self):
         """Test that register_file_view raises ValueError for empty paths."""
         profiler = GizmoDuckDbProfiler(
-            uri="grpc://localhost:10501",
+            uri="grpc+tls://localhost:31337",
             username="test_user",
             password="test_pass",
         )
@@ -113,7 +113,7 @@ class TestGizmoProfilerConfiguration:
     def test_clear_views(self):
         """Test that clear_views removes all registered views."""
         profiler = GizmoDuckDbProfiler(
-            uri="grpc://localhost:10501",
+            uri="grpc+tls://localhost:31337",
             username="test_user",
             password="test_pass",
         )

--- a/tests/test_parquet_profiling_integration.py
+++ b/tests/test_parquet_profiling_integration.py
@@ -114,7 +114,7 @@ To run these integration tests, you need:
 1. A running GizmoSQL instance
 2. Set environment variables:
 
-export TEST_GIZMOSQL_URI="grpc://localhost:10501"
+export TEST_GIZMOSQL_URI="grpc+tls://localhost:31337"
 export TEST_GIZMOSQL_USERNAME="test_user"
 export TEST_GIZMOSQL_PASSWORD="test_pass"
 

--- a/tests/test_sql_injection_prevention.py
+++ b/tests/test_sql_injection_prevention.py
@@ -11,7 +11,7 @@ class TestSQLInjectionPrevention:
     def test_metadata_location_with_single_quotes_escaped(self):
         """Test that single quotes in metadata locations are properly escaped."""
         profiler = GizmoDuckDbProfiler(
-            uri="grpc://localhost:10501",
+            uri="grpc+tls://localhost:31337",
             username="test",
             password="test",
         )
@@ -40,7 +40,7 @@ class TestSQLInjectionPrevention:
     def test_metadata_location_without_quotes_unchanged(self):
         """Test that normal metadata locations work correctly."""
         profiler = GizmoDuckDbProfiler(
-            uri="grpc://localhost:10501",
+            uri="grpc+tls://localhost:31337",
             username="test",
             password="test",
         )
@@ -63,7 +63,7 @@ class TestSQLInjectionPrevention:
     def test_multiple_single_quotes_escaped(self):
         """Test that multiple single quotes are all properly escaped."""
         profiler = GizmoDuckDbProfiler(
-            uri="grpc://localhost:10501",
+            uri="grpc+tls://localhost:31337",
             username="test",
             password="test",
         )
@@ -86,7 +86,7 @@ class TestSQLInjectionPrevention:
     def test_snapshot_id_not_escaped(self):
         """Test that snapshot_id (integer) is not escaped."""
         profiler = GizmoDuckDbProfiler(
-            uri="grpc://localhost:10501",
+            uri="grpc+tls://localhost:31337",
             username="test",
             password="test",
         )
@@ -108,7 +108,7 @@ class TestSQLInjectionPrevention:
     def test_no_snapshot_id_escaping(self):
         """Test metadata escaping when no snapshot ID is provided."""
         profiler = GizmoDuckDbProfiler(
-            uri="grpc://localhost:10501",
+            uri="grpc+tls://localhost:31337",
             username="test",
             password="test",
         )
@@ -131,7 +131,7 @@ class TestSQLInjectionPrevention:
     def test_empty_metadata_location(self):
         """Test that empty metadata location raises ValueError."""
         profiler = GizmoDuckDbProfiler(
-            uri="grpc://localhost:10501",
+            uri="grpc+tls://localhost:31337",
             username="test",
             password="test",
         )


### PR DESCRIPTION
- Update GizmoSQL server URI from grpc://localhost:10501 to grpc+tls://localhost:31337 across all documentation
- Change server startup command to use TLS flags (-T) with self-signed certificates
- Update tls_skip_verify configuration from false to true for local development
- Add clarification comments about default port and TLS configuration options
- Update health check and connectivity verification commands to use new port
- Standardize GizmoSQL configuration examples in README, QUICKSTART, USER_GUIDE, ARCHITECTURE, and DEVELOPER_GUIDE
- Update test fixtures and integration test documentation with new URI format
- Ensure consistent configuration across all deployment and setup guides

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches GizmoSQL defaults to TLS on port 31337, updates docs/tests/config accordingly, and makes the client set TLS options only when using a TLS URI.
> 
> - **Profiling Backend (`GizmoDuckDbProfiler`)**:
>   - Conditional TLS: set `DatabaseOptions.TLS_SKIP_VERIFY` only when `uri` starts with `grpc+tls://` in `_connect()`.
> - **TUI**:
>   - Update connection error guidance to new `gizmosql_server` startup command with TLS flags.
> - **Configuration**:
>   - Default `table_sleuth.toml` `gizmosql.uri` -> `grpc+tls://localhost:31337`; `tls_skip_verify = true`.
> - **Tests**:
>   - Update URIs in `tests/*` to `grpc+tls://localhost:31337` and health checks to `31337`.
> - **Documentation** (README, QUICKSTART, USER_GUIDE, CONTRIBUTING, ARCHITECTURE, DEVELOPER_GUIDE, `docs/gizmosql-deployment.md`):
>   - Standardize on `grpc+tls://localhost:31337` and TLS startup flags; adjust health checks, env vars, examples, and diagrams to new port.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91af96a520b8413f402af931bbcdbee47ece11cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->