### PR TITLE
chore: bump version to 0.2.2 and suppress AWS SDK logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "table-sleuth"
-version = "0.2.1"
+version = "0.2.2"
 description = "Table Sleuth - a Textual TUI for Open Table Format forensics (OTF) with data profiling."
 readme = "README.md"
 requires-python = ">=3.13,<3.15"

--- a/src/table_sleuth/cli.py
+++ b/src/table_sleuth/cli.py
@@ -78,6 +78,11 @@ def inspect(path: str, catalog_name: str | None, verbose: bool) -> None:
     else:
         logging.basicConfig(level=logging.INFO)
 
+    # Suppress noisy AWS SDK logs
+    logging.getLogger("botocore").setLevel(logging.WARNING)
+    logging.getLogger("boto3").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
     # Load configuration
     config = load_config()
     adapter = IcebergAdapter(default_catalog=config.catalog.default)
@@ -265,6 +270,11 @@ def iceberg_viewer(
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.INFO)
+
+    # Suppress noisy AWS SDK logs
+    logging.getLogger("botocore").setLevel(logging.WARNING)
+    logging.getLogger("boto3").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
 
     # Load configuration
     config = load_config()


### PR DESCRIPTION
- Update project version from 0.2.1 to 0.2.2 in pyproject.toml
- Suppress verbose logging from botocore, boto3, and urllib3 in inspect command
- Suppress verbose logging from botocore, boto3, and urllib3 in iceberg_viewer command
- Reduce noise in application logs from AWS SDK dependencies while maintaining application-level logging control

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Suppresses noisy AWS SDK logs in CLI commands and bumps the package version to 0.2.2.
> 
> - **CLI**:
>   - `inspect`: Suppresses `botocore`, `boto3`, and `urllib3` logs by setting level to `WARNING`.
>   - `iceberg` viewer: Applies the same AWS SDK log suppression.
> - **Packaging**:
>   - Bumps `project.version` in `pyproject.toml` to `0.2.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4662857ef24e68d8ae008874d5ee79537550172f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->