### PR TITLE
fix(iceberg): improve operation field extraction from snapshot metadata

### DIFF
--- a/src/table_sleuth/services/iceberg_metadata_service.py
+++ b/src/table_sleuth/services/iceberg_metadata_service.py
@@ -137,8 +137,13 @@ class IcebergMetadataService:
                 else {}
             )
 
-            # Get operation from summary
-            operation = summary.get("operation", "UNKNOWN")
+            # Get operation from summary or snapshot object
+            # Try multiple possible locations for the operation
+            operation = summary.get("operation")
+            if not operation and hasattr(snapshot, "operation"):
+                operation = str(snapshot.operation) if snapshot.operation else None
+            if not operation:
+                operation = "UNKNOWN"
 
             # Extract metrics from summary
             total_records = int(summary.get("total-records", 0))


### PR DESCRIPTION
- Add fallback logic to retrieve operation from snapshot object when not in summary
- Check snapshot.operation attribute as secondary source for operation value
- Default to "UNKNOWN" only when operation is not found in either location
- Improve robustness of metadata extraction for Iceberg snapshots with varying metadata structures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve snapshot operation extraction by falling back to `snapshot.operation` when absent in summary, defaulting to "UNKNOWN" otherwise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0da8a1a9b421883675cb4f8bea9f7f6e66d10faa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->