### PR TITLE
style(tui): update application titles and remove column display limit

### DIFF
--- a/src/table_sleuth/tui/app.py
+++ b/src/table_sleuth/tui/app.py
@@ -44,7 +44,7 @@ class TableSleuthApp(App):
       - Profile results
     """
 
-    TITLE = "Table Sleuth - Parquet Inspector"
+    TITLE = "Table Sleuth - Parquet Analysis"
     SUB_TITLE = "Parquet Forensics & Iceberg Analysis"
 
     CSS = """

--- a/src/table_sleuth/tui/views/iceberg_view.py
+++ b/src/table_sleuth/tui/views/iceberg_view.py
@@ -232,7 +232,7 @@ class IcebergView(Screen):
     - Performance testing capabilities
     """
 
-    TITLE = "Iceberg Metadata Viewer"
+    TITLE = "Table Sleuth - Iceberg Analysis"
 
     CSS = """
     IcebergView {

--- a/src/table_sleuth/tui/views/row_groups_view.py
+++ b/src/table_sleuth/tui/views/row_groups_view.py
@@ -119,13 +119,13 @@ class RowGroupsView(Container):
 
             # Build rows of column panels
             cols_per_row = 3
-            max_cols_to_show = min(len(rg.columns), 15)  # Limit display
+            num_cols = len(rg.columns)
 
-            for row_idx in range(0, max_cols_to_show, cols_per_row):
+            for row_idx in range(0, num_cols, cols_per_row):
                 row_panels: list[Panel | Text] = []
                 for col_offset in range(cols_per_row):
                     col_idx = row_idx + col_offset
-                    if col_idx < max_cols_to_show:
+                    if col_idx < num_cols:
                         col = rg.columns[col_idx]
                         col_panel = self._create_column_panel(col)
                         row_panels.append(col_panel)
@@ -134,15 +134,6 @@ class RowGroupsView(Container):
                         row_panels.append(Text(""))
 
                 col_table.add_row(*row_panels)
-
-            # If too many columns, add note
-            if len(rg.columns) > max_cols_to_show:
-                remaining_text = Text()
-                remaining_text.append(
-                    f"... and {len(rg.columns) - max_cols_to_show} more columns",
-                    style="dim italic",
-                )
-                col_table.add_row(Panel(remaining_text, border_style="dim"), Text(""), Text(""))
 
             # Create collapsible widget
             collapsible = Collapsible(


### PR DESCRIPTION
- Change main app title from "Parquet Inspector" to "Parquet Analysis"
- Update Iceberg view title to "Table Sleuth - Iceberg Analysis" for consistency
- Remove 15-column display limit in row groups view to show all columns
- Simplify column iteration logic by using actual column count instead of capped value
- Remove "more columns" truncation notice that is no longer needed
- Improve user experience by displaying complete column information without artificial limits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the 15-column cap in row groups to display all columns and updates app and Iceberg view titles for consistency.
> 
> - **UI/UX**:
>   - **Row Groups (`src/table_sleuth/tui/views/row_groups_view.py`)**:
>     - Remove 15-column display limit; render all columns.
>     - Drop truncation notice and simplify iteration using actual column count.
>   - **Titles**:
>     - Update app `TITLE` in `src/table_sleuth/tui/app.py` to `"Table Sleuth - Parquet Analysis"`.
>     - Update Iceberg view `TITLE` in `src/table_sleuth/tui/views/iceberg_view.py` to `"Table Sleuth - Iceberg Analysis"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfdd3958a9b8b8fbca90748a5826b897184affd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->