### PR TITLE
style(tui): remove subtitle from application header

### DIFF
--- a/src/table_sleuth/tui/app.py
+++ b/src/table_sleuth/tui/app.py
@@ -45,7 +45,7 @@ class TableSleuthApp(App):
     """
 
     TITLE = "Table Sleuth - Parquet Analysis"
-    SUB_TITLE = "Parquet Forensics & Iceberg Analysis"
+    SUB_TITLE = ""
 
     CSS = """
     Screen {

--- a/tests/test_app_layout.py
+++ b/tests/test_app_layout.py
@@ -64,7 +64,7 @@ def test_app_has_title(
     )
 
     assert app.TITLE == "Table Sleuth - Parquet Analysis"
-    assert app.SUB_TITLE == "Parquet Forensics & Iceberg Analysis"
+    assert app.SUB_TITLE == ""
 
 
 def test_app_has_keybindings(


### PR DESCRIPTION
- Clear SUB_TITLE in TableSleuthApp to display empty string instead of "Parquet Forensics & Iceberg Analysis"
- Update corresponding test assertion in test_app_layout.py to expect empty SUB_TITLE
- Simplify application header display by removing descriptive subtitle text

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `TableSleuthApp.SUB_TITLE` to an empty string and update test to expect the empty subtitle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfa27f02f29162afffb2403ee76d20df6c33dcd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->