### PR TITLE
fix: resolve PyPI image display and update to 0.4.2.post1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.2.post1] - 2026-01-17
+
+### Fixed
+- **PyPI Package Display** - Fixed broken image links on PyPI project page
+  - Changed relative image paths to absolute GitHub URLs
+  - Images now display correctly on https://pypi.org/project/tablesleuth/
+  - Uses `raw.githubusercontent.com` URLs for reliable image hosting
+
 ## [0.4.2] - 2026-01-17
 
 ### Added
@@ -46,11 +54,19 @@ All notable changes to this project will be documented in this file.
   - Fixed unhandled exception in `config-check` command with invalid `TABLESLEUTH_CONFIG` environment variable
   - Both commands now show helpful error messages suggesting `tablesleuth init` instead of tracebacks
   - Added proper try-except blocks around `load_config()` calls in main CLI commands
+  - Fixed misleading "No config file found (using defaults)" message after `TABLESLEUTH_CONFIG` error
+  - Fixed incorrect init suggestion for non-config FileNotFoundError in `iceberg` command
 
 - **Configuration Template TOML Syntax** - Fixed invalid TOML in generated config
   - Changed `default = null` to commented `# default = ""` (TOML doesn't support null type)
   - Generated config files now parse correctly without `TOMLDecodeError`
   - Affects `tablesleuth init` command output
+
+- **Configuration Init Command** - Improved Windows compatibility
+  - Removed backup file creation when using `--force` flag
+  - Files are now directly overwritten instead of being backed up
+  - Fixes Windows `FileExistsError` when running `init --force` multiple times
+  - Simplifies the init process
 
 - **S3 Tables Catalog Configuration** - Fixed incorrect catalog type and improved flexibility
   - Changed S3 Tables catalog from `type: glue` to `type: rest` with proper REST API settings

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ A powerful terminal-based tool for deep inspection of Parquet files and Apache I
 <td width="50%">
 
 **File Structure & Schema**
-![Parquet Structure](docs/images/parquet_structure.png)
+![Parquet Structure](https://raw.githubusercontent.com/jamesbconner/TableSleuth/main/docs/images/parquet_structure.png)
 
 </td>
 <td width="50%">
 
 **Row Group Analysis**
-![Row Groups](docs/images/parquet_row_groups.png)
+![Row Groups](https://raw.githubusercontent.com/jamesbconner/TableSleuth/main/docs/images/parquet_row_groups.png)
 
 </td>
 </tr>
@@ -52,13 +52,13 @@ A powerful terminal-based tool for deep inspection of Parquet files and Apache I
 <td width="50%">
 
 **Data Sample View**
-![Data Sample](docs/images/parquet_data_sample.png)
+![Data Sample](https://raw.githubusercontent.com/jamesbconner/TableSleuth/main/docs/images/parquet_data_sample.png)
 
 </td>
 <td width="50%">
 
 **Column Profiling**
-![Profile](docs/images/parquet_profile.png)
+![Profile](https://raw.githubusercontent.com/jamesbconner/TableSleuth/main/docs/images/parquet_profile.png)
 
 </td>
 </tr>
@@ -71,13 +71,13 @@ A powerful terminal-based tool for deep inspection of Parquet files and Apache I
 <td width="50%">
 
 **Snapshot Overview**
-![Iceberg Overview](docs/images/iceberg_overview.png)
+![Iceberg Overview](https://raw.githubusercontent.com/jamesbconner/TableSleuth/main/docs/images/iceberg_overview.png)
 
 </td>
 <td width="50%">
 
 **Performance Testing**
-![Performance](docs/images/iceberg_performance_sample.png)
+![Performance](https://raw.githubusercontent.com/jamesbconner/TableSleuth/main/docs/images/iceberg_performance_sample.png)
 
 </td>
 </tr>
@@ -85,13 +85,13 @@ A powerful terminal-based tool for deep inspection of Parquet files and Apache I
 <td width="50%">
 
 **Delete Files (MOR)**
-![Deletes](docs/images/iceberg_deletes.png)
+![Deletes](https://raw.githubusercontent.com/jamesbconner/TableSleuth/main/docs/images/iceberg_deletes.png)
 
 </td>
 <td width="50%">
 
 **Snapshot Comparison**
-![Compare](docs/images/iceberg_compare.png)
+![Compare](https://raw.githubusercontent.com/jamesbconner/TableSleuth/main/docs/images/iceberg_compare.png)
 
 </td>
 </tr>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tablesleuth"
-version = "0.4.2"
+version = "0.4.2.post1"
 description = "TableSleuth - a Textual TUI for Open Table Format forensics (OTF) with data profiling."
 readme = "README.md"
 requires-python = ">=3.13,<3.15"

--- a/src/tablesleuth/__init__.py
+++ b/src/tablesleuth/__init__.py
@@ -1,4 +1,4 @@
 """TableSleuth - open table format forensics."""
 
 __all__ = ["__version__"]
-__version__ = "0.4.2"
+__version__ = "0.4.2.post1"


### PR DESCRIPTION
- Fix broken image links in README by converting relative paths to absolute GitHub URLs
- Changed all image references to use `raw.githubusercontent.com` for reliable hosting
- Images now display correctly on PyPI project page
- Update version to 0.4.2.post1 in pyproject.toml and __init__.py
- Update CHANGELOG.md with post-release fixes and improvements
- Added entry for PyPI package display fixes
- Documented additional config error handling improvements
- Noted Windows compatibility fix for init --force command
- These changes ensure proper image rendering on PyPI and document recent bug fixes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses PyPI rendering and release metadata updates.
> 
> - Switches README screenshot links to `raw.githubusercontent.com` absolute URLs to fix image display on PyPI
> - Bumps version to `0.4.2.post1` in `pyproject.toml` and `src/tablesleuth/__init__.py`
> - Updates `CHANGELOG.md` with 0.4.2.post1 entry and notes additional fixes (clearer config error messages, Windows `init --force` behavior)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcb2c5ffc3155b86116b2ea9b57dd0da819d87d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->